### PR TITLE
fix #38 修复找回密码验证码串扰

### DIFF
--- a/apps/home/controller/MemberController.php
+++ b/apps/home/controller/MemberController.php
@@ -270,7 +270,7 @@ class MemberController extends Controller
             if (! $checkcode) {
                 alert_back('验证码不能为空！');
             }
-            if ($checkcode != session('checkcode')) {
+            if ($checkcode != session('retrieve_checkcode')) {
                 alert_back('验证码错误！');
             }
             $where = ['username' => $username];
@@ -278,14 +278,14 @@ class MemberController extends Controller
             if(!$userInfo){
                 alert_back('该用户不存在！');
             }
-            if(!empty($userInfo['useremail']) && $userInfo['useremail'] != $email){
+            if(empty($userInfo['useremail']) || strcasecmp($userInfo['useremail'], $email) !== 0){
                 alert_back('与注册邮箱不匹配，请联系管理员！');
             }
             $data = [
-                'useremail' => $email,
                 'password' => md5(md5($password))
             ];
             $this->model->updatePassword($where,$data);
+            unset($_SESSION['retrieve_checkcode']);
             alert_location('修改成功！', Url::home('member/login'), 1);
         } else {
             $content = parent::parser($this->htmldir . 'member/retrieve.html'); // 框架标签解析
@@ -499,7 +499,7 @@ class MemberController extends Controller
             session('lastsend', time()); // 记录最后提交时间
             $mail_subject = "【" . CMSNAME . "】您有新的验证码信息，请注意查收！";
             $code = create_code(4);
-            session('checkcode', strtolower($code));
+            session($retrieve ? 'retrieve_checkcode' : 'checkcode', strtolower($code));
             $mail_body = "您的验证码为：" . $code;
             $mail_body .= '<br>来自网站 ' . get_http_url() . ' （' . date('Y-m-d H:i:s') . '）';
             $rs = sendmail($this->config(), $to, $mail_subject, $mail_body);

--- a/apps/home/controller/MemberController.php
+++ b/apps/home/controller/MemberController.php
@@ -265,12 +265,15 @@ class MemberController extends Controller
             // 验证码验证
             $checkcode = strtolower(post('checkcode', 'var'));
             $email = post('email');
+            $retrieve_email = strtolower(trim($email));
             $username = post('username');
             $password = post('password');
             if (! $checkcode) {
                 alert_back('验证码不能为空！');
             }
-            if ($checkcode != session('retrieve_checkcode')) {
+            $retrieve_checkcode = session('retrieve_checkcode');
+            $session_retrieve_email = session('retrieve_email');
+            if (! $retrieve_checkcode || ! $session_retrieve_email || $checkcode != $retrieve_checkcode || $retrieve_email != $session_retrieve_email) {
                 alert_back('验证码错误！');
             }
             $where = ['username' => $username];
@@ -286,6 +289,7 @@ class MemberController extends Controller
             ];
             $this->model->updatePassword($where,$data);
             unset($_SESSION['retrieve_checkcode']);
+            unset($_SESSION['retrieve_email']);
             alert_location('修改成功！', Url::home('member/login'), 1);
         } else {
             $content = parent::parser($this->htmldir . 'member/retrieve.html'); // 框架标签解析
@@ -500,6 +504,9 @@ class MemberController extends Controller
             $mail_subject = "【" . CMSNAME . "】您有新的验证码信息，请注意查收！";
             $code = create_code(4);
             session($retrieve ? 'retrieve_checkcode' : 'checkcode', strtolower($code));
+            if ($retrieve) {
+                session('retrieve_email', strtolower(trim($to)));
+            }
             $mail_body = "您的验证码为：" . $code;
             $mail_body .= '<br>来自网站 ' . get_http_url() . ' （' . date('Y-m-d H:i:s') . '）';
             $rs = sendmail($this->config(), $to, $mail_subject, $mail_body);


### PR DESCRIPTION
## Summary
Fixes #38.

This patch fixes an account takeover issue in the member password recovery flow.

## Changes
- Use a dedicated `retrieve_checkcode` session key for password recovery verification codes.
- Require the submitted email to match the member's existing registered email.
- Prevent password recovery from rewriting the `useremail` field.
- Clear `retrieve_checkcode` after a successful password reset to avoid code reuse.

## Verification
- `php -l apps/home/controller/MemberController.php`
