### PR TITLE
新增 GitHub labels 与 PR 自动打标流程

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,18 @@
+needs review:
+  - changed-files:
+      - any-glob-to-any-file: '**'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - README.md
+          - doc/**
+          - docs/**
+
+bug:
+  - head-branch: '^fix/'
+  - head-branch: '^bugfix/'
+
+enhancement:
+  - head-branch: '^feat/'
+  - head-branch: '^feature/'

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,39 @@
+- name: following
+  color: 78D64B
+  description: Issue has been seen and is being followed by a maintainer
+
+- name: needs info
+  color: FBCA04
+  description: More information is needed from the reporter
+
+- name: confirmed
+  color: 215CEA
+  description: Issue has been confirmed or accepted
+
+- name: in progress
+  color: 73DBC4
+  description: Work is currently in progress
+
+- name: needs review
+  color: 5319E7
+  description: Pull request is ready for maintainer review
+
+- name: ready to merge
+  color: 1D7136
+  description: Pull request has been reviewed and is ready to merge
+
+- name: 🔴 P0
+  color: B60205
+  description: P0 - Critical priority, immediate action required
+
+- name: 🟠 P1
+  color: D93F0B
+  description: P1 - High priority, should be handled first
+
+- name: 🟡 P2
+  color: FBCA04
+  description: P2 - Medium priority, handle as planned
+
+- name: 🟢 P3
+  color: 0E8A16
+  description: P3 - Low priority, can be handled later

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,21 @@
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/lgtm-label.yml
+++ b/.github/workflows/lgtm-label.yml
@@ -1,0 +1,63 @@
+name: LGTM Label
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  lgtm:
+    if: github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.issue.number;
+            const commenter = context.payload.comment.user.login;
+            const command = context.payload.comment.body.trim().toUpperCase();
+
+            if (command !== 'LGTM') {
+              core.info(`Ignoring comment: ${context.payload.comment.body}`);
+              return;
+            }
+
+            const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner,
+              repo,
+              username: commenter,
+            });
+
+            const allowedPermissions = new Set(['admin', 'maintain', 'write']);
+            if (!allowedPermissions.has(permission.permission)) {
+              core.info(`Ignoring LGTM from ${commenter}: permission is ${permission.permission}.`);
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: ['ready to merge'],
+            });
+
+            for (const name of ['needs review', 'in progress']) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number,
+                  name,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }


### PR DESCRIPTION
## 变更内容

- 新增 `.github/labels.yml`，记录 10 个 GitHub labels：状态标签与 P0-P3 优先级标签
- 新增官方 `actions/labeler@v6` workflow，根据 PR 文件变更和分支名自动打标
- 新增 `LGTM` 评论指令 workflow：维护者评论 LGTM 后自动切换到 `ready to merge`

## 自动化行为

- 所有 PR 自动加 `needs review`
- 文档变更自动加 `documentation`
- `fix/*` / `bugfix/*` 分支自动加 `bug`
- `feat/*` / `feature/*` 分支自动加 `enhancement`
- PR 评论 `LGTM` 时：添加 `ready to merge`，移除 `needs review` 和 `in progress`

## 验证

- 已使用 Ruby YAML 标准库校验所有 YAML 文件
- 已确认分支基于 `master`，不包含 `review` 分支提交
