### PR TITLE
fix #23 修复标签页模板注入风险

### DIFF
--- a/apps/home/controller/TagController.php
+++ b/apps/home/controller/TagController.php
@@ -29,10 +29,11 @@ class TagController extends Controller
     {
         // 在非兼容模式接受地址第二参数值
         if (defined('RVAR')) {
-            $_GET['tag'] = RVAR;
+            $_GET['tag'] = constant('\RVAR');
         }
         
-        if (! get('tag')) {
+        $tag = get('tag', 'vars');
+        if (! $tag) {
             _404('您访问的页面不存在，请核对后重试！');
         }
         
@@ -42,8 +43,8 @@ class TagController extends Controller
         }
         $content = parent::parser($this->htmldir . $tagstpl); // 框架标签解析
         $content = $this->parser->parserBefore($content); // CMS公共标签前置解析
-        $content = $this->parser->parserPositionLabel($content, 0, '相关内容', Url::home('tag/' . get('tag'))); // CMS当前位置标签解析
-        $content = $this->parser->parserSpecialPageSortLabel($content, - 2, '相关内容', Url::home('tag/' . get('tag'))); // 解析分类标签
+        $content = $this->parser->parserPositionLabel($content, 0, '相关内容', Url::home('tag/' . $tag)); // CMS当前位置标签解析
+        $content = $this->parser->parserSpecialPageSortLabel($content, - 2, '相关内容', Url::home('tag/' . $tag)); // 解析分类标签
         $content = $this->parser->parserAfter($content); // CMS公共标签后置解析
         $this->cache($content, true);
     }


### PR DESCRIPTION
## 变更
- 在 `TagController` 中统一使用 `get('tag', 'vars')` 校验 tag 输入。
- 复用校验后的 `$tag` 构造当前位置和分类链接，避免模板标签进入 `parserAfter()` 二次解析。
- 使用 `constant('\\RVAR')` 读取全局 `RVAR`，避免命名空间常量解析问题。

## 验证
- `php -l apps/home/controller/TagController.php`
- LSP diagnostics: no diagnostics
- PoC payload 被 `vars` 规则拒绝，正常 tag 仍可通过

Fixes #23