### PR TITLE
调整 LGTM 指令为斜杠命令

### DIFF
--- a/.github/workflows/lgtm-label.yml
+++ b/.github/workflows/lgtm-label.yml
@@ -21,9 +21,9 @@ jobs:
             const { owner, repo } = context.repo;
             const issue_number = context.payload.issue.number;
             const commenter = context.payload.comment.user.login;
-            const command = context.payload.comment.body.trim().toUpperCase();
+            const command = context.payload.comment.body.trim();
 
-            if (command !== '/LGTM') {
+            if (!['/lgtm', '/LGTM'].includes(command)) {
               core.info(`Ignoring comment: ${context.payload.comment.body}`);
               return;
             }

--- a/.github/workflows/lgtm-label.yml
+++ b/.github/workflows/lgtm-label.yml
@@ -23,7 +23,7 @@ jobs:
             const commenter = context.payload.comment.user.login;
             const command = context.payload.comment.body.trim().toUpperCase();
 
-            if (command !== 'LGTM') {
+            if (command !== '/LGTM') {
               core.info(`Ignoring comment: ${context.payload.comment.body}`);
               return;
             }
@@ -36,7 +36,7 @@ jobs:
 
             const allowedPermissions = new Set(['admin', 'maintain', 'write']);
             if (!allowedPermissions.has(permission.permission)) {
-              core.info(`Ignoring LGTM from ${commenter}: permission is ${permission.permission}.`);
+              core.info(`Ignoring /lgtm from ${commenter}: permission is ${permission.permission}.`);
               return;
             }
 


### PR DESCRIPTION
## 变更内容

- 将 LGTM 评论触发方式收紧为机器人指令
- 仅支持 `/lgtm` 和 `/LGTM`
- 不再支持普通 `LGTM`、`lgtm` 或混合大小写 `/LgTm`

## 验证

- 已使用 Ruby YAML 标准库校验 workflow YAML
- 分支 `chore/lgtm-slash-command` 已推送到 origin
