### PR TITLE
修复 LGTM 标签工作流权限

### DIFF
--- a/.github/workflows/lgtm-label.yml
+++ b/.github/workflows/lgtm-label.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   lgtm:


### PR DESCRIPTION
## 变更内容

- 将 `LGTM Label` workflow 的 `pull-requests` 权限从 `read` 调整为 `write`
- 修复 `/lgtm` 添加 PR label 时的 `Resource not accessible by integration` 403 错误

## 原因

GitHub label API 在 PR 上写入 label 时需要 `issues=write` 和 `pull_requests=write` 权限。当前 workflow 已有 `issues: write`，但缺少 `pull-requests: write`。

## 验证

- 已使用 Ruby YAML 标准库校验 workflow YAML
- 分支基于最新 `origin/master`，仅包含本次权限修复提交
