### PR TITLE
安全加固: 为 UpgradeController::down() 增加文件类型白名单和路径校验

### DIFF
--- a/apps/admin/controller/system/UpgradeController.php
+++ b/apps/admin/controller/system/UpgradeController.php
@@ -113,6 +113,15 @@ class UpgradeController extends Controller
         }
     }
 
+    // 允许下载的文件扩展名白名单
+    private $allowedExts = array(
+        'php', 'html', 'htm', 'css', 'js', 'json', 'xml', 'sql',
+        'jpg', 'jpeg', 'png', 'gif', 'bmp', 'ico', 'svg',
+        'zip', 'rar', 'doc', 'docx', 'ppt', 'pptx', 'xls', 'xlsx',
+        'ttf', 'otf', 'woff', 'woff2', 'eot', 'txt', 'md', 'woff', 'woff2',
+        'mp4', 'mp3', 'webm', 'avi', 'flv', 'pdf'
+    );
+
     // 执行下载
     public function down()
     {
@@ -126,13 +135,36 @@ class UpgradeController extends Controller
             foreach ($list as $value) {
                 // 过滤掉相对路径
                 $value = preg_replace_r('{\.\.(\/|\\\\)}', '', $value);
+
+                // 安全加固：禁止绝对路径（以/开头）
+                if (strpos($value, '/') === 0) {
+                    $this->log("非法文件路径: $value");
+                    json(0, '非法的文件路径！');
+                }
+
+                // 安全加固：文件扩展名白名单检查
+                $ext = strtolower(pathinfo($value, PATHINFO_EXTENSION));
+                if (! in_array($ext, $this->allowedExts)) {
+                    $this->log("不允许的文件类型: $value (扩展名: $ext)");
+                    json(0, '不允许的文件类型：' . $ext);
+                }
+
+                // 安全加固：禁止下载敏感路径文件
+                $forbiddenPaths = array('core/basic/Kernel.php', 'core/basic/Check.php', 'core/start.php', 'admin.php', 'index.php');
+                foreach ($forbiddenPaths as $forbidden) {
+                    if (stripos($value, $forbidden) !== false) {
+                        $this->log("尝试下载敏感文件: $value");
+                        json(0, '禁止下载系统敏感文件！');
+                    }
+                }
+
                 // 本地存储路径
                 $path = RUN_PATH . '/upgrade' . $value;
                 // 自动创建目录
                 if (! check_dir(dirname($path), true)) {
                     json(0, '目录写入权限不足，无法下载升级文件！' . dirname($path));
                 }
-                
+
                 // 定义执行下载的类型
                 $types = '.zip|.rar|.doc|.docx|.ppt|.pptx|.xls|.xlsx|.chm|.ttf|.otf|';
                 $pathinfo = explode(".", basename($path));


### PR DESCRIPTION
 ## 问题描述
  `UpgradeController::down()` 方法用于从远程服务器下载更新文件。原实现仅过滤了 `../` 路径遍历序列，但存在以下安全隐患：
  - 未限制绝对路径（如 `/admin.php`）
  - 未校验文件扩展名
  - 未阻止下载敏感系统文件（Kernel.php、Check.php 等）

  攻击者在获取后台权限后，可利用此功能下载任意文件进行信息收集。

  ## 修复内容
  - 新增 `$allowedExts` 文件扩展名白名单，只允许下载官方更新所需的文件类型
  - 禁止以 `/` 开头的绝对路径
  - 新增敏感系统文件黑名单（Kernel.php、Check.php、start.php、admin.php、index.php）
  - 增加安全审计日志，记录违规操作

  ## 测试验证
  已测试以下场景：
  - `list=/admin.php` → 被拒绝（绝对路径）
  - `list=/../../etc/passwd` → 被拒绝（绝对路径）
  - `list=core/basic/Kernel.php` → 被拒绝（敏感文件）
  - `list=apps/home/controller/IndexController.php` → 允许（合法的更新文件）

  ## 关联
  基于 PbootCMS 3.2.15 安全性评估报告：升级系统功能仍可作为攻击入口，需要额外加固。