### PR TITLE
安全加固: 用可疑代码模式检测替换有缺陷的反篡改检查

### DIFF
--- a/apps/home/controller/ParserController.php
+++ b/apps/home/controller/ParserController.php
@@ -265,8 +265,8 @@ class ParserController extends Controller
                             $content = str_replace($matches[0][$i], '', $content);
                         }
                     default:
-                        if (strpos(file_get_contents(CORE_PATH . base64_decode('L2Jhc2ljL0tlcm5lbC5waHA=')), base64_decode('S2VybmVs')))
-                            exit();
+                        // 安全加固：核心文件完整性校验（替代原来有缺陷的字符串包含检查）
+                        $this->checkCoreFileIntegrity();
                         if (isset($data->{$matches[1][$i]})) {
                             $content = str_replace($matches[0][$i], $this->adjustLabelData($params, $data->{$matches[1][$i]}), $content);
                         } else {
@@ -3330,6 +3330,56 @@ class ParserController extends Controller
 
         // 7. 如果仍有残留内容，说明存在不允许的 token（如函数名、$变量、%取模等）
         return ($test === '');
+    }
+
+    // 核心文件完整性检查（替代原来有缺陷的字符串包含检查）
+    // 检查核心文件是否被植入可疑代码
+    private function checkCoreFileIntegrity()
+    {
+        static $checked = false;
+        if ($checked) {
+            return;
+        }
+        $checked = true;
+
+        $coreFiles = array(
+            CORE_PATH . '/basic/Kernel.php',
+            CORE_PATH . '/basic/Check.php',
+            CORE_PATH . '/start.php'
+        );
+
+        // 可疑代码模式：用于检测 webshell、跳转劫持、后门等
+        $suspiciousPatterns = array(
+            // eval + base64_decode 组合（典型 webshell）
+            '/eval\s*\(\s*base64_decode\s*\(/i',
+            // file_put_contents 写入 PHP 文件
+            '/file_put_contents\s*\([^)]*\.php/i',
+            // 页面跳转劫持
+            '/<meta\s+http-equiv=["\']?refresh["\']?/i',
+            // 混淆的变量函数调用（如 $a="eval"; $a(...)）
+            '/\$\w+\s*=\s*["\']\s*(eval|assert|system|exec|passthru|shell_exec)\s*["\'];\s*\$\w+\s*\(/i',
+            // 包含远程文件
+            '/include\s*\(\s*[\"\']https?:\/\//i',
+            // 危险的文件操作函数组合
+            '/(copy|file_get_contents)\s*\(\s*[\"\']https?:\/\/[^\"\']+\.(zip|rar|php)/i',
+            // base64 编码的 eval
+            '/ZXZhbA==|YXNzZXJ0|c3lzdGVt|ZXhlYw==|cGFzc3RocnU=|c2hlbGxfZXhlYw==/i',
+        );
+
+        foreach ($coreFiles as $file) {
+            if (! file_exists($file)) {
+                continue;
+            }
+            $content = file_get_contents($file);
+            foreach ($suspiciousPatterns as $pattern) {
+                if (preg_match($pattern, $content)) {
+                    // 发现可疑代码，记录日志并终止执行
+                    logger("SECURITY ALERT: Suspicious code detected in $file");
+                    http_response_code(503);
+                    exit('System security check failed. Please contact administrator.');
+                }
+            }
+        }
     }
 
     // 解析IF条件标签


### PR DESCRIPTION
## 问题描述
  原代码通过检查 `Kernel.php` 中是否包含字符串 `"Kernel"` 来判断文件是否被篡改：
  ```php
  if (strpos(file_get_contents(CORE_PATH . '/basic/Kernel.php'), 'Kernel'))
      exit();

  这个检查存在严重缺陷：
  - 仅验证文件是否包含 "Kernel" 字符串
  - 攻击者的混淆后门代码可以通过 base64 编码保留该字符串，完美绕过检查
  - 该检查不仅无法发现后门，反而帮助攻击者隐藏（后门通过了"合法性"校验）
  - 没有任何日志记录，管理员无法发现被篡改

  修复内容

  - 移除有缺陷的字符串包含检查
  - 新增 checkCoreFileIntegrity() 方法，使用正则表达式检测可疑代码模式：
    - eval(base64_decode(...)) — 典型 webshell
    - file_put_contents(... .php) — 文件写入后门
    - <meta http-equiv=refresh> — 页面跳转劫持
    - 混淆变量函数调用（$a="eval"; $a(...)）
    - 远程文件包含（include('http://...')）
    - 危险的远程文件下载+执行组合
  - 发现可疑代码时记录安全日志并返回 HTTP 503 终止执行

  测试验证

  - 正常代码可通过检测
  - 常见 webshell 模式可触发保护
  - 告警日志正确记录
